### PR TITLE
Kill dnsmasq instead of dhcp and restore previous iptables rules

### DIFF
--- a/usr/share/mana-toolkit/run-mana/start-nat-full-lollipop.sh
+++ b/usr/share/mana-toolkit/run-mana/start-nat-full-lollipop.sh
@@ -37,8 +37,13 @@ ip route add 10.0.0.0/24 dev $phy scope link table $table
 # http://lists.netfilter.org/pipermail/netfilter-buglog/2013-October/002995.html
 iptables -F bw_INPUT
 iptables -F bw_OUTPUT
+
 # Save
-# iptables-save > /tmp/rules.txt
+iptables-save > /tmp/rules.txt
+# Remove non-working export lines
+sed --in-place '/rmnet0/d' /tmp/rules.txt
+sed --in-place '/TCPMSS/d' /tmp/rules.txt
+
 # Flush
 iptables --policy INPUT ACCEPT
 iptables --policy FORWARD ACCEPT
@@ -86,7 +91,8 @@ sleep 5
 
 echo "Hit enter to kill me"
 read
-pkill dhcpd
+#pkill dhcpd
+pkill dnsmasq
 pkill sslstrip
 pkill sslsplit
 pkill hostapd

--- a/usr/share/mana-toolkit/run-mana/start-nat-simple-bdf-lollipop.sh
+++ b/usr/share/mana-toolkit/run-mana/start-nat-simple-bdf-lollipop.sh
@@ -37,8 +37,14 @@ ip route add 10.0.0.0/24 dev $phy scope link table $table
 # http://lists.netfilter.org/pipermail/netfilter-buglog/2013-October/002995.html
 iptables -F bw_INPUT
 iptables -F bw_OUTPUT
+
 # Save
-# iptables-save > /tmp/rules.txt
+iptables-save > /tmp/rules.txt
+# Remove non-working export lines
+sed --in-place '/rmnet0/d' /tmp/rules.txt
+sed --in-place '/TCPMSS/d' /tmp/rules.txt
+
+
 # Flush
 iptables --policy INPUT ACCEPT
 iptables --policy FORWARD ACCEPT
@@ -63,14 +69,17 @@ echo $! > /tmp/bdfproxy.pid
 
 echo "Hit enter to kill me"
 read
-pkill dhcpd
+#pkill dhcpd
+pkill dnsmasq
 pkill sslstrip
 pkill sslsplit
 pkill hostapd
 pkill python
+
 # Restore
-# iptables-restore < /tmp/rules.txt
-# rm /tmp/rules.txt
+iptables-restore < /tmp/rules.txt
+rm /tmp/rules.txt
+
 # Remove iface and routes
 ip addr flush dev $phy
 ip link set $phy down

--- a/usr/share/mana-toolkit/run-mana/start-nat-simple-lollipop.sh
+++ b/usr/share/mana-toolkit/run-mana/start-nat-simple-lollipop.sh
@@ -37,8 +37,13 @@ ip route add 10.0.0.0/24 dev $phy scope link table $table
 # http://lists.netfilter.org/pipermail/netfilter-buglog/2013-October/002995.html
 iptables -F bw_INPUT
 iptables -F bw_OUTPUT
+
 # Save
-# iptables-save > /tmp/rules.txt
+iptables-save > /tmp/rules.txt
+# Remove non-working export lines
+sed --in-place '/rmnet0/d' /tmp/rules.txt
+sed --in-place '/TCPMSS/d' /tmp/rules.txt
+
 # Flush
 iptables -F
 iptables -F -t nat
@@ -48,14 +53,17 @@ iptables -A FORWARD -i $phy -o $upstream -j ACCEPT
 
 echo "Hit enter to kill me"
 read
-pkill dhcpd
+#pkill dhcpd
+pkill dnsmasq
 pkill sslstrip
 pkill sslsplit
 pkill hostapd
 pkill python
-## Restore
-#iptables-restore < /tmp/rules.txt
-#rm /tmp/rules.txt
-## Remove iface and routes
+
+# Restore
+iptables-restore < /tmp/rules.txt
+rm /tmp/rules.txt
+
+# Remove iface and routes
 ip addr flush dev $phy
 ip link set $phy down


### PR DESCRIPTION
I've found that when mana stops dhcp service from dnsmasq (udp: 53) was still running.
While reading source I've found that iptables-restore process was comented out, while trying to make it works it appears some lines were preventing correct restore.